### PR TITLE
Facility dropdown is disabled until a governor is selected.

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -30,10 +30,12 @@ document.addEventListener(
     "change",
     (changeEvent) => {
         if (changeEvent.target.id === "governors") {
+            const facilitySelection = document.getElementById("facility")
             if (changeEvent.target.value > 0) {
-                document.getElementById("facility").disabled = false;
+                facilitySelection.disabled = false;
             } else {
-                document.getElementById("facility").disabled = true;
+                facilitySelection.disabled = true;
+                facilitySelection.selectedIndex = 0;
             }
         }
     }

--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -8,7 +8,7 @@ const facilities = getFacilities()
 export const Facilities = () => {
     let html = `<section class="facility-selection-section">
     <p>Choose a facility</p>
-    <select id='facility'>
+    <select id='facility' disabled>
     <option value='0'>Select a facility</option>`
 
     //use map array method to iterate through facilities, create dropdown option for each facility, and output to an array
@@ -25,4 +25,17 @@ export const Facilities = () => {
 
     return html
 }
+
+document.addEventListener(
+    "change",
+    (changeEvent) => {
+        if (changeEvent.target.id === "governors") {
+            if (changeEvent.target.value > 0) {
+                document.getElementById("facility").disabled = false;
+            } else {
+                document.getElementById("facility").disabled = true;
+            }
+        }
+    }
+)
 


### PR DESCRIPTION
# Description

Added a change event listener in Facilities.js that looks out for changes of the governor drop down box. Facilities dropdown box is disabled by default and becomes enabled once a governor has been selected, becomes disabled again if no governor is selected.

Fixes # 22

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Serve code, facility dropdown should be disabled until a governor is selected. 

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
