### PR TITLE
governor selection shows current minerals at colony

### DIFF
--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,4 +1,5 @@
-import { getColonies, getColonyMineralJoins, getGovernors } from "./database.js"
+import { getColonies, getGovernors } from "./database.js"
+import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables
 const governors = getGovernors()
@@ -12,9 +13,8 @@ document.addEventListener('change', (event) => {
         // finds colongy for selected governor
         const selectedColony = colonies.find(col => col.id === selectedGovernor.colonyId)
         // updates HTML to show colony name 
-        document.querySelector('.colony-inv-container').innerHTML = `<h2>${selectedColony.name} Minerals</h2>`
+        document.querySelector('.colony-inv-container').innerHTML = `<h2>${selectedColony.name} Minerals</h2> ${CurrentColonyMinerals(selectedColony)}`
     }
-
 })
 
 // makes and exports 'choose a governor' dropdown

--- a/scripts/Minerals.js
+++ b/scripts/Minerals.js
@@ -1,0 +1,15 @@
+import { getColonyMineralJoins, getMinerals } from "./database.js";
+
+
+export const CurrentColonyMinerals = (colony) => {
+    const joins = getColonyMineralJoins()
+    const minerals = getMinerals()
+    let html = ""
+    joins.forEach((join) => {
+        if (join.colonyId === colony.id) {
+            const mineral = minerals.find(m => m.id === join.mineralId)
+            html += `<p>${join.tons} tons of ${mineral.name}</p>`
+        }
+    })
+    return html
+}

--- a/scripts/Minerals.js
+++ b/scripts/Minerals.js
@@ -1,12 +1,16 @@
 import { getColonyMineralJoins, getMinerals } from "./database.js";
 
-
-export const CurrentColonyMinerals = (colony) => {
+// export function to create current minerals html
+export const CurrentColonyMinerals = (colony) => { // takes selectedColony from Governors.js eventListener as parameter
+    // assign imported data to variables
     const joins = getColonyMineralJoins()
     const minerals = getMinerals()
+    // declare empty string
     let html = ""
+    // iterate all colony-mineral joins
     joins.forEach((join) => {
         if (join.colonyId === colony.id) {
+            // find mineral that matches join
             const mineral = minerals.find(m => m.id === join.mineralId)
             html += `<p>${join.tons} tons of ${mineral.name}</p>`
         }


### PR DESCRIPTION
# Description

When governor is chosen,  the current number of available minerals at that colony will be displayed under the heading: 
**"(Colony Name) Minerals"**

Fixes # (26)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] fetch `cg-show-current-minerals`
- [ ] open in VSCode and serve
- [ ] check code in **Minerals.js** for accuracy
- [ ] check code in **Governors.js** for accuracy (line 16)
- [ ] check browser for expected functionality by choosing different governors (Lala Wolff is currently the only governor with minerals assigned to their colony)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
