### PR TITLE
Cg refactor governor event listener

### DIFF
--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -2,6 +2,7 @@
 import { Facilities } from "./Facilities.js"
 import { Governors } from "./Governors.js"
 import { FacilityInventory } from "./FacilityInventory.js"
+import { Minerals } from "./Minerals.js"
 
 // HTML builder function that will be imported to main.js. Put everything in containers so we can apply flexbox and structure it like the wireframe later on.
 export const Exomine = () => {
@@ -18,7 +19,7 @@ export const Exomine = () => {
         </section>
 
         <section class="colony-inv-container">
-            <h2>Colony Minerals</h2>
+            ${Minerals()}
         </section>
 
     </section>

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,4 +1,4 @@
-import { getColonies, getGovernors, setGovernor } from "./database.js"
+import { getColonies, getGovernors, getTransientState, setGovernor } from "./database.js"
 // import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables
@@ -8,19 +8,19 @@ const colonies = getColonies()
 // event listener for governor selection
 document.addEventListener('change', (event) => {
     if (event.target.name === "governors") {
-        // finds selected governor
-        // const selectedGovernor = governors.find(gov => gov.id === parseInt(event.target.value))
-        // finds colongy for selected governor
-        // const selectedColony = colonies.find(col => col.id === selectedGovernor.colonyId)
-        // updates HTML to show colony name 
-        // document.querySelector('.colony-inv-container').innerHTML = `<h2>${selectedColony.name} Minerals</h2> ${CurrentColonyMinerals(selectedColony)}`
+        // find selected governor id
         const govId = parseInt(event.target.value)
+        // update transient state
         setGovernor(govId)
     }
 })
 
 // makes and exports 'choose a governor' dropdown
 export const Governors = () => {
+    
+    // get transient state
+    let transientState = getTransientState()
+
     // opening tag
     let html = `<section class="governor-selection-section">
     <p>Choose a Governor</p>
@@ -32,9 +32,12 @@ export const Governors = () => {
             (gov) => {
             // checks if governor is active
             if (gov.isActive) {
-                // template for list option
-                html += `<option value="${gov.id}">${gov.name}</option>`
-            }
+                if (transientState.selectedGovernor > 0 && gov.id === transientState.selectedGovernor) {
+                    html += `<option value="${gov.id}" selected="selected">${gov.name}</option>`
+                } else {
+                    html += `<option value="${gov.id}" >${gov.name}</option>`
+                }
+            } 
         }
     )
     // closing tag

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,5 +1,5 @@
-import { getColonies, getGovernors } from "./database.js"
-import { CurrentColonyMinerals } from "./Minerals.js"
+import { getColonies, getGovernors, setGovernor } from "./database.js"
+// import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables
 const governors = getGovernors()
@@ -9,11 +9,13 @@ const colonies = getColonies()
 document.addEventListener('change', (event) => {
     if (event.target.name === "governors") {
         // finds selected governor
-        const selectedGovernor = governors.find(gov => gov.id === parseInt(event.target.value))
+        // const selectedGovernor = governors.find(gov => gov.id === parseInt(event.target.value))
         // finds colongy for selected governor
-        const selectedColony = colonies.find(col => col.id === selectedGovernor.colonyId)
+        // const selectedColony = colonies.find(col => col.id === selectedGovernor.colonyId)
         // updates HTML to show colony name 
-        document.querySelector('.colony-inv-container').innerHTML = `<h2>${selectedColony.name} Minerals</h2> ${CurrentColonyMinerals(selectedColony)}`
+        // document.querySelector('.colony-inv-container').innerHTML = `<h2>${selectedColony.name} Minerals</h2> ${CurrentColonyMinerals(selectedColony)}`
+        const govId = parseInt(event.target.value)
+        setGovernor(govId)
     }
 })
 
@@ -21,9 +23,9 @@ document.addEventListener('change', (event) => {
 export const Governors = () => {
     // opening tag
     let html = `<section class="governor-selection-section">
-    <p>Choose governor function here</p>
+    <p>Choose a Governor</p>
     <select name="governors" id="governors">
-        <option value="0" selected>Select a governor</option>`
+        <option value="0" >Select a governor</option>`
 
 
         governors.forEach(

--- a/scripts/Minerals.js
+++ b/scripts/Minerals.js
@@ -1,19 +1,19 @@
-import { getColonyMineralJoins, getMinerals } from "./database.js";
+// import { getColonyMineralJoins, getMinerals } from "./database.js";
 
-// export function to create current minerals html
-export const CurrentColonyMinerals = (colony) => { // takes selectedColony from Governors.js eventListener as parameter
-    // assign imported data to variables
-    const joins = getColonyMineralJoins()
-    const minerals = getMinerals()
-    // declare empty string
-    let html = ""
-    // iterate all colony-mineral joins
-    joins.forEach((join) => {
-        if (join.colonyId === colony.id) {
-            // find mineral that matches join
-            const mineral = minerals.find(m => m.id === join.mineralId)
-            html += `<p>${join.tons} tons of ${mineral.name}</p>`
-        }
-    })
-    return html
-}
+// // export function to create current minerals html
+// export const CurrentColonyMinerals = (colony) => { // takes selectedColony from Governors.js eventListener as parameter
+//     // assign imported data to variables
+//     const joins = getColonyMineralJoins()
+//     const minerals = getMinerals()
+//     // declare empty string
+//     let html = ""
+//     // iterate all colony-mineral joins
+//     joins.forEach((join) => {
+//         if (join.colonyId === colony.id) {
+//             // find mineral that matches join
+//             const mineral = minerals.find(m => m.id === join.mineralId)
+//             html += `<p>${join.tons} tons of ${mineral.name}</p>`
+//         }
+//     })
+//     return html
+// }

--- a/scripts/Minerals.js
+++ b/scripts/Minerals.js
@@ -1,19 +1,38 @@
-// import { getColonyMineralJoins, getMinerals } from "./database.js";
+import { getColonies, getColonyMineralJoins, getGovernors, getMinerals, getTransientState } from "./database.js";
 
-// // export function to create current minerals html
-// export const CurrentColonyMinerals = (colony) => { // takes selectedColony from Governors.js eventListener as parameter
-//     // assign imported data to variables
-//     const joins = getColonyMineralJoins()
-//     const minerals = getMinerals()
-//     // declare empty string
-//     let html = ""
-//     // iterate all colony-mineral joins
-//     joins.forEach((join) => {
-//         if (join.colonyId === colony.id) {
-//             // find mineral that matches join
-//             const mineral = minerals.find(m => m.id === join.mineralId)
-//             html += `<p>${join.tons} tons of ${mineral.name}</p>`
-//         }
-//     })
-//     return html
-// }
+export const Minerals = () => {
+    // get minerals, joins, transientState, governers and colonies
+    const minerals = getMinerals() // array
+    const joins = getColonyMineralJoins() // array
+    const transientState = getTransientState() // object
+    const governors = getGovernors() // array
+    const colonies = getColonies() // array
+    
+    // empty string
+    let html = ''
+
+    // check status of selectedGoverner property
+    if (transientState.selectedGovernor === 0 || transientState.selectedGovernor === undefined) {
+        html += '<h2>Colony Minerals</h2>'
+    } else if (transientState.selectedGovernor > 0) {
+
+        // find selected governor
+        const gov = governors.find(gov => gov.id === transientState.selectedGovernor)
+        // find governor's colony
+        const col = colonies.find(col => col.id === gov.colonyId)
+        // add colony name to html
+        html += `<h2>${col.name} Minerals</h2>`
+        
+        // iterate joins
+        joins.forEach((join) => {
+            // find joins for colony
+            if (join.colonyId === col.id) {
+                // find minerals for join
+                const min = minerals.find(min => min.id === join.mineralId)
+                // add amount and mineral name to html
+                html += `<p>${join.tons} tons of ${min.name}</p>`
+            }
+        })
+    }
+    return html
+}

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -175,7 +175,7 @@ export const getMineralFacilityJoins = () => {
 }
 
 export const getTransientState = () => {
-    return database.transientState
+    return {...database.transientState} 
 }
 
 export const purchaseMineral = () => {
@@ -187,12 +187,6 @@ export const purchaseMineral = () => {
 
 export const setGovernor = (governorId) => {
     database.transientState.selectedGovernor = governorId
-    if (governorId > 0) {
-        database.transientState.isGovernorSelected = true
-    } else {
-        database.transientState.isGovernorSelected = false
-    }
-    console.log(database.transientState.selectedGovernor, database.transientState.isGovernorSelected)
     document.dispatchEvent(new CustomEvent("stateChanged"))
 }
 

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -4,28 +4,28 @@ const database = {
             id: 1,
             name: 'Patricia Purdy',
             colonyId: 2,
-            isActive: true 
+            isActive: true
         },
         {
             id: 2,
             name: 'Katrina Bahringer',
             colonyId: 3,
-            isActive: true 
+            isActive: true
         },
         {
             id: 3,
             name: 'Lala Wolff',
             colonyId: 1,
-            isActive: true 
+            isActive: true
         },
         {
             id: 4,
             name: 'Damon Hartmann',
             colonyId: 2,
-            isActive: true 
+            isActive: true
         },
         {
-            id:5,
+            id: 5,
             name: 'Jake Sully',
             colonyId: 1,
             isActive: false
@@ -98,7 +98,7 @@ const database = {
             mineralId: 2,
             tons: 2
         }
-        
+
     ],
     mineralFacilityJoins: [
         {
@@ -138,12 +138,12 @@ const database = {
             tons: 4
         }
     ],
-    transientState: [
+    transientState: 
         {
             id: 0,
 
         }
-    ]
+    
 }
 
 export const setFacility = (facilityId) => {
@@ -156,29 +156,40 @@ export const getFacilities = () => {
 }
 
 export const getGovernors = () => {
-    return database.governors.map(g => ({...g}))
+    return database.governors.map(g => ({ ...g }))
 }
 
 export const getColonies = () => {
-    return database.colonies.map(c => ({...c}))
+    return database.colonies.map(c => ({ ...c }))
 }
 
 export const getMinerals = () => {
-    return database.minerals.map(m => ({...m}))
+    return database.minerals.map(m => ({ ...m }))
 }
 
 export const getColonyMineralJoins = () => {
-    return database.colonyMineralJoins.map(j => ({...j}))
+    return database.colonyMineralJoins.map(j => ({ ...j }))
 }
 
 export const getMineralFacilityJoins = () => {
-    return database.mineralFacilityJoins.map(j => ({...j}))
+    return database.mineralFacilityJoins.map(j => ({ ...j }))
 }
 
 export const purchaseMineral = () => {
 
     // Broadcast custom event to entire documement so that the
     // application can re-render and update state
+    document.dispatchEvent(new CustomEvent("stateChanged"))
+}
+
+export const setGovernor = (governorId) => {
+    database.transientState.selectedGovernor = governorId
+    if (governorId > 0) {
+        database.transientState.isGovernorSelected = true
+    } else {
+        database.transientState.isGovernorSelected = false
+    }
+    console.log(database.transientState.selectedGovernor, database.transientState.isGovernorSelected)
     document.dispatchEvent(new CustomEvent("stateChanged"))
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -19,8 +19,4 @@ const renderAllHTML = () => {
 // invoke renderAllHTML function.
 renderAllHTML()
 
-document.addEventListener("stateChanged", event => {
-    console.log("State of data has changed. Regenerating Html...")
-    renderAllHTML()
-})
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -10,3 +10,9 @@ const renderAllHTML = () => {
 
 // invoke renderAllHTML function.
 renderAllHTML()
+
+document.addEventListener("stateChanged", event => {
+    console.log("State of data has changed. Regenerating Html...")
+    renderAllHTML()
+})
+


### PR DESCRIPTION
# Description

- changed event listener in **Governers.js** line 9 to only get the value of selected governor and call setGovernor function with that value as its argument
- changed `Governors()` function to check transient state and build the dropdown list, using the current value of the selected option as its new default
- in **Minerals.js** changed `Minerals()` function to check transient state and build the minerals HTML based on the selected governor. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] fetch `cg-refactor-governor-event-listener`
- [ ] open VSCode and serve
- [ ] check **Governors.js** and **Minerals.js** for code accuracy
- [ ] check browser using dev tools for proper functionality (selected governor should remain selected on change, minerals HTML should update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
