### PR TITLE
Based dropdown disabling on state, not event listener. 

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -9,7 +9,7 @@ export const Facilities = () => {
     let transientState = getTransientState()
     let html = `<section class="facility-selection-section">
     <p>Choose a facility</p>
-    <select id='facility' disabled>
+    <select id='facility'>
     <option value='0'>Select a facility</option>`
 
     //use map array method to iterate through facilities, create dropdown option for each facility, and output to an array
@@ -18,18 +18,19 @@ export const Facilities = () => {
             // check to see if facility is active
             if (facility.isActive) {
                 // check to see if current facility is what was selected on transient state - make that one "selected" for when html generates.
-                if (facility.id === transientState.selectedFacility) {
-                    return `<option value="${facility.id}" selected>${facility.name}</option>`
-                } else {
-                    return `<option value="${facility.id}">${facility.name}</option>`
-                }
+                return optionHtmlBuilder(facility,transientState)
             }
         }
     )
+
+
     //use join method to combine all strings in facilityArray into one string
     html += facilityArray.join(" ")
     html += "</select></section>"
 
+    /*
+    disableFacilities(transientState)
+    */
     return html
 }
 
@@ -56,3 +57,24 @@ document.addEventListener(
         }
     }
 )
+
+/*
+const disableFacilities = (transientStateObj) => {
+    const facilitySelection = document.getElementById("facility")
+    if (transientStateObj.selectedGovernor === undefined || transientStateObj.selectedGovernor === 0) {
+        facilitySelection.disabled = true
+        facilitySelection.selectedIndex = 0
+    } else {
+        facilitySelection.disabled = false
+    }
+}
+
+*/
+
+const optionHtmlBuilder = (facility, transientStateObj) => {
+    if (facility.id === transientStateObj.selectedFacility) {
+        return `<option value="${facility.id}" selected>${facility.name}</option>`
+    } else {
+        return `<option value="${facility.id}">${facility.name}</option>`
+    }
+}

--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -1,75 +1,23 @@
 // import facility data
-import { getFacilities, setFacility, getTransientState } from "./database.js"
+import { getFacilities, setFacility, getTransientState, setFacilityMineral } from "./database.js"
 
 //assign facility data to a variable
 const facilities = getFacilities()
 
 // create function to export to Exomine that will build html for facility dropdown box 
 export const Facilities = () => {
+    // get transient state
     let transientState = getTransientState()
+
+    //create section for dropdown box
     let html = `<section class="facility-selection-section">
-    <p>Choose a facility</p>
-    <select id='facility'>
-    <option value='0'>Select a facility</option>`
+    <p>Choose a facility</p>`
 
-    //use map array method to iterate through facilities, create dropdown option for each facility, and output to an array
-    const facilityArray = facilities.map(
-        (facility) => {
-            // check to see if facility is active
-            if (facility.isActive) {
-                // check to see if current facility is what was selected on transient state - make that one "selected" for when html generates.
-                return optionHtmlBuilder(facility,transientState)
-            }
-        }
-    )
+    //invoke htmlStringBuilder function, add this to html string
+    html += htmlStringBuilder(transientState)
 
-
-    //use join method to combine all strings in facilityArray into one string
-    html += facilityArray.join(" ")
-    html += "</select></section>"
-
-    /*
-    disableFacilities(transientState)
-    */
-    return html
+    return html    
 }
-
-document.addEventListener(
-    "change",
-    (changeEvent) => {
-        if (changeEvent.target.id === "governors") {
-            const facilitySelection = document.getElementById("facility")
-            if (changeEvent.target.value > 0) {
-                facilitySelection.disabled = false;
-            } else {
-                facilitySelection.disabled = true;
-                facilitySelection.selectedIndex = 0;
-            }
-        }
-    }
-)
-
-document.addEventListener(
-    "change",
-    (changeEvent) => {
-        if (changeEvent.target.id === "facility") {
-            setFacility(parseInt(changeEvent.target.value))
-        }
-    }
-)
-
-/*
-const disableFacilities = (transientStateObj) => {
-    const facilitySelection = document.getElementById("facility")
-    if (transientStateObj.selectedGovernor === undefined || transientStateObj.selectedGovernor === 0) {
-        facilitySelection.disabled = true
-        facilitySelection.selectedIndex = 0
-    } else {
-        facilitySelection.disabled = false
-    }
-}
-
-*/
 
 const optionHtmlBuilder = (facility, transientStateObj) => {
     if (facility.id === transientStateObj.selectedFacility) {
@@ -77,4 +25,52 @@ const optionHtmlBuilder = (facility, transientStateObj) => {
     } else {
         return `<option value="${facility.id}">${facility.name}</option>`
     }
+}
+
+document.addEventListener(
+    "change",
+    (changeEvent) => {
+        if (changeEvent.target.id === "facility") {
+            setFacility(parseInt(changeEvent.target.value))
+            setFacilityMineral(0)
+        }
+    }
+)
+
+const htmlStringBuilder = (transientStateObj) => {
+    //create empty html string
+    let html = ""
+    // Check to see if governor has been selected (selectedGovernor > 0)
+    if (transientStateObj.selectedGovernor > 0) {
+
+        //create header and base option that are not disabled
+        html += `<select id='facility'>
+        <option value='0'>Select a facility</option>`
+
+        //use map array method to iterate through facilities, create dropdown option for each facility, and output to an array
+        const facilityArray = facilities.map(
+            (facility) => {
+                // check to see if facility is active
+                if (facility.isActive) {
+                    // check to see if current facility is what was selected on transient state - make that one "selected" for when html generates.
+                    return optionHtmlBuilder(facility, transientStateObj)
+                }
+            }
+        )
+        //use join method to combine all strings in facilityArray into one string
+        html += facilityArray.join(" ")
+
+    // If governor is NOT selected or user has de-selected a governor...
+    } else {
+        
+        //create header and base option that ARE disabled.
+        html += `<select id='facility' disabled>
+        <option value='0'>Select a facility</option>`
+        
+    }
+
+    // close select and section tags
+    html += "</select></section>"
+
+    return html
 }

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,4 +1,4 @@
-import { getColonies, getGovernors, getTransientState, setGovernor } from "./database.js"
+import { getColonies, getGovernors, getTransientState, setGovernor, setFacility, setFacilityMineral } from "./database.js"
 // import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables
@@ -10,6 +10,13 @@ document.addEventListener('change', (event) => {
     if (event.target.name === "governors") {
         // find selected governor id
         const govId = parseInt(event.target.value)
+
+        // check to see if govId is 0 - this means governor has been deselected.
+        if (govId === 0) {
+            // reset selectedfacility to 0
+            setFacility(0)
+            setFacilityMineral(0)
+        }
         // update transient state
         setGovernor(govId)
     }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,9 +1,11 @@
 import { Exomine } from "./Exomine.js"
+import {getTransientState} from "./database.js"
 
 document.addEventListener(
     "stateChanged",
     (stateChanged) => {
         console.log("State Changed! Rerendering html...")
+        console.log(getTransientState())
         renderAllHTML()
     }
 )


### PR DESCRIPTION
# Description

Before this update, disabling the facility selection dropdown box was based on an event listener, not the transient state. updated Facilities.js to read the transient state and use this to decide how to generate html. Also updated event listener in governors function so transientState.selectedFacilities and transientState.selectedFacilityMineral are reset when the governor is de-selected.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. serve page in browser
2. make sure html is populating correctly - try selecting a governor, then facility, then mineral, and deselecting governor and see how html responds.
3. I added a console log statement that shows transient state whenever html is regenerated - make sure transient state for both facility and mineral reset when governor is deselected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
