### PR TITLE
radio buttons will not be generated for any minerals with an amount of 0

### DIFF
--- a/scripts/FacilityInventory.js
+++ b/scripts/FacilityInventory.js
@@ -32,7 +32,7 @@ export const FacilityInventory = () => {
         const facilityInventoryArray = mineralFacilityJoins.map(
             (facilityMineral) => {
                 //Find which mineralFacilityJoin objects have facilityId's equal to the facility Id on the transient state.
-                if (facilityMineral.facilityId === transientState.selectedFacility) {
+                if (facilityMineral.facilityId === transientState.selectedFacility && facilityMineral.tons > 0) {
                     //if IDs match, feed data into radio button builder function
                     return radioButtonBuilder(facilityMineral,transientState)
                 }

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -136,6 +136,12 @@ const database = {
             mineralId: 2,
             facilityId: 3,
             tons: 4
+        },
+        {
+            id: 7,
+            mineralId: 1,
+            facilityId: 3,
+            tons: 0
         }
     ],
     transientState: 


### PR DESCRIPTION
# Description

Added another conditional in the portion of the function FacilityInventory that decides whether a radio button will be generated for a mineral. Function only generates radio buttons for minerals with tons > 0. 

Also added another object to the facilityMineralJoins array in database whose tons are = 0. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. check to see that new object is in database.js. Object should have properties of...
 * id = 7
 * mineralId: 1, (chromium)
 * facilityId: 3, (titan)
 * tons: 0
2. serve in browser, make sure that a radio button does NOT populate for this object when Titan is selected as the facility.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
