### PR TITLE
added setMineral functionality

### DIFF
--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -2,6 +2,7 @@
 import { Facilities } from "./Facilities.js"
 import { Governors } from "./Governors.js"
 import { FacilityInventory, showCart, } from "./FacilityInventory.js"
+import { Minerals } from "./Minerals.js"
 
 // HTML builder function that will be imported to main.js. Put everything in containers so we can apply flexbox and structure it like the wireframe later on.
 export const Exomine = () => {

--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -1,7 +1,7 @@
 //import statements will go here
 import { Facilities } from "./Facilities.js"
 import { Governors } from "./Governors.js"
-import { FacilityInventory, showCart, } from "./FacilityInventory.js"
+import { FacilityInventory } from "./FacilityInventory.js"
 import { Minerals } from "./Minerals.js"
 
 // HTML builder function that will be imported to main.js. Put everything in containers so we can apply flexbox and structure it like the wireframe later on.
@@ -31,7 +31,7 @@ export const Exomine = () => {
         </section>
 
         <section class="cart-section">
-            ${showCart()}
+            
             <button type="button" id="purchaseButton">Purchase Mineral</button>
         </section>
 

--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -1,7 +1,7 @@
 //import statements will go here
 import { Facilities } from "./Facilities.js"
 import { Governors } from "./Governors.js"
-import { FacilityInventory } from "./FacilityInventory.js"
+import { FacilityInventory, showCart, } from "./FacilityInventory.js"
 
 // HTML builder function that will be imported to main.js. Put everything in containers so we can apply flexbox and structure it like the wireframe later on.
 export const Exomine = () => {
@@ -30,7 +30,7 @@ export const Exomine = () => {
         </section>
 
         <section class="cart-section">
-            <h2>Cart function here</h2>
+            ${showCart()}
             <button type="button" id="purchaseButton">Purchase Mineral</button>
         </section>
 

--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -1,5 +1,5 @@
 // import facility data
-import { getFacilities, setFacility, getTransientState, setFacilityMineral } from "./database.js"
+import { getFacilities, setFacility, getTransientState, setFacilityMineral, setMineral } from "./database.js"
 
 //assign facility data to a variable
 const facilities = getFacilities()
@@ -33,6 +33,7 @@ document.addEventListener(
         if (changeEvent.target.id === "facility") {
             setFacility(parseInt(changeEvent.target.value))
             setFacilityMineral(0)
+            setMineral(0)
         }
     }
 )

--- a/scripts/FacilityInventory.js
+++ b/scripts/FacilityInventory.js
@@ -1,5 +1,5 @@
 // import all data necessary
-import { getMineralFacilityJoins, getFacilities, getMinerals, getTransientState, setFacilityMineral } from "./database.js"
+import { getMineralFacilityJoins, getFacilities, getMinerals, getTransientState, setFacilityMineral, setMineral } from "./database.js"
 
 // assign data to variables
 
@@ -18,8 +18,8 @@ export const FacilityInventory = () => {
     if (transientState.selectedFacility === undefined || transientState.selectedFacility === 0) {
         // If thats the case, print out generic header
         html += "<h2>Facility inventory</h2>"
-
-        // if a facility HAS been selected, do the following
+    
+    // if a facility HAS been selected, do the following
     } else {
 
         // find out what facility was selected
@@ -34,7 +34,7 @@ export const FacilityInventory = () => {
                 //Find which mineralFacilityJoin objects have facilityId's equal to the facility Id on the transient state.
                 if (facilityMineral.facilityId === transientState.selectedFacility && facilityMineral.tons > 0) {
                     //if IDs match, feed data into radio button builder function
-                    return radioButtonBuilder(facilityMineral, transientState)
+                    return radioButtonBuilder(facilityMineral,transientState)
                 }
             }
         )
@@ -65,7 +65,7 @@ const findFacility = (transientStateObj) => {
 }
 
 //this function creates a radio button for each type of mineral within selected facility
-const radioButtonBuilder = (facilityMineral, transientStateObj) => {
+const radioButtonBuilder = (facilityMineral,transientStateObj) => {
     let foundMineral = findMineral(facilityMineral)
     if (facilityMineral.id === transientStateObj.selectedFacilityMineral) {
         return `<li>
@@ -83,46 +83,8 @@ document.addEventListener(
     (changeEvent) => {
         if (changeEvent.target.name === "inventory") {
             setFacilityMineral(parseInt(changeEvent.target.value))
+            const foundMineralFacilityJoin = mineralFacilityJoins.find( mineralFacility => )
         }
     }
 )
-//event listener to add selected minerals to cart 
 
-document.addEventListener(
-    "click",
-    (changeEvent) => {
-        if (changeEvent.target.name === "inventory") {
-
-        }
-    }
-)
-export const showCart = () => {
-
-    let html = `<ul class="cart-section">
-                 <li class="cart-section">`
-
-
-    let transientState = getTransientState()
-    let foundMineral = findMineral(transientState)
-    let foundFacility = findFacility(transientState)
-
-    /* for (const mineral of minerals){
-     if (mineral.id === transientState.selectedFacilityMineral) {
-         return mineral.name
-     }
- */
-if (transientState.selectedFacilityMineral === 0 || transientState.selectedFacilityMineral === undefined){
-    html += `</li> </ul>`
-}
-else {
-
-    let selectedMineral = minerals.find(mineral => mineral.id === transientState.selectedFacilityMineral)
-
-    console.log(`1 ton of ${selectedMineral.name} from ${foundFacility} `)
-    console.log(transientState)
-
-    html += `1 ton of ${selectedMineral.name} from ${foundFacility} </li> </ul>`
-}
-    return html
-
-}

--- a/scripts/FacilityInventory.js
+++ b/scripts/FacilityInventory.js
@@ -18,8 +18,8 @@ export const FacilityInventory = () => {
     if (transientState.selectedFacility === undefined || transientState.selectedFacility === 0) {
         // If thats the case, print out generic header
         html += "<h2>Facility inventory</h2>"
-    
-    // if a facility HAS been selected, do the following
+
+        // if a facility HAS been selected, do the following
     } else {
 
         // find out what facility was selected
@@ -34,7 +34,7 @@ export const FacilityInventory = () => {
                 //Find which mineralFacilityJoin objects have facilityId's equal to the facility Id on the transient state.
                 if (facilityMineral.facilityId === transientState.selectedFacility) {
                     //if IDs match, feed data into radio button builder function
-                    return radioButtonBuilder(facilityMineral,transientState)
+                    return radioButtonBuilder(facilityMineral, transientState)
                 }
             }
         )
@@ -65,7 +65,7 @@ const findFacility = (transientStateObj) => {
 }
 
 //this function creates a radio button for each type of mineral within selected facility
-const radioButtonBuilder = (facilityMineral,transientStateObj) => {
+const radioButtonBuilder = (facilityMineral, transientStateObj) => {
     let foundMineral = findMineral(facilityMineral)
     if (facilityMineral.id === transientStateObj.selectedFacilityMineral) {
         return `<li>
@@ -86,4 +86,43 @@ document.addEventListener(
         }
     }
 )
+//event listener to add selected minerals to cart 
 
+document.addEventListener(
+    "click",
+    (changeEvent) => {
+        if (changeEvent.target.name === "inventory") {
+
+        }
+    }
+)
+export const showCart = () => {
+
+    let html = `<ul class="cart-section">
+                 <li class="cart-section">`
+
+
+    let transientState = getTransientState()
+    let foundMineral = findMineral(transientState)
+    let foundFacility = findFacility(transientState)
+
+    /* for (const mineral of minerals){
+     if (mineral.id === transientState.selectedFacilityMineral) {
+         return mineral.name
+     }
+ */
+if (transientState.selectedFacilityMineral === 0 || transientState.selectedFacilityMineral === undefined){
+    html += `</li> </ul>`
+}
+else {
+
+    let selectedMineral = minerals.find(mineral => mineral.id === transientState.selectedFacilityMineral)
+
+    console.log(`1 ton of ${selectedMineral.name} from ${foundFacility} `)
+    console.log(transientState)
+
+    html += `1 ton of ${selectedMineral.name} from ${foundFacility} </li> </ul>`
+}
+    return html
+
+}

--- a/scripts/FacilityInventory.js
+++ b/scripts/FacilityInventory.js
@@ -82,8 +82,9 @@ document.addEventListener(
     "change",
     (changeEvent) => {
         if (changeEvent.target.name === "inventory") {
-            setFacilityMineral(parseInt(changeEvent.target.value))
-            const foundMineralFacilityJoin = mineralFacilityJoins.find( mineralFacility => )
+            const foundMineralFacilityJoin = mineralFacilityJoins.find( mineralFacility => mineralFacility.id === parseInt(changeEvent.target.value))
+            setFacilityMineral(foundMineralFacilityJoin.id)
+            setMineral(foundMineralFacilityJoin.mineralId)
         }
     }
 )

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,4 +1,4 @@
-import { getColonies, getGovernors, getTransientState, setGovernor, setFacility, setFacilityMineral } from "./database.js"
+import { getColonies, getGovernors, getTransientState, setGovernor, setFacility, setFacilityMineral, setMineral } from "./database.js"
 // import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables
@@ -16,6 +16,7 @@ document.addEventListener('change', (event) => {
             // reset selectedfacility and selectedFacilityMineral to 0
             setFacility(0)
             setFacilityMineral(0)
+            setMineral(0)
         }
         // update transient state
         setGovernor(govId)

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,4 +1,4 @@
-import { getColonies, getGovernors, getTransientState, setGovernor, setFacility, setFacilityMineral, setColony } from "./database.js"
+import { getColonies, getGovernors, getTransientState, setGovernor, setFacility, setFacilityMineral, setColony, setMineral } from "./database.js"
 // import { CurrentColonyMinerals } from "./Minerals.js"
 
 // assign imported arrays to variables

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -13,7 +13,7 @@ document.addEventListener('change', (event) => {
 
         // check to see if govId is 0 - this means governor has been deselected.
         if (govId === 0) {
-            // reset selectedfacility to 0
+            // reset selectedfacility and selectedFacilityMineral to 0
             setFacility(0)
             setFacilityMineral(0)
         }

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -191,6 +191,26 @@ export const getTransientState = () => {
 
 export const purchaseMineral = () => {
 
+    //This function will be called when purchase button is selected - event listener will be added to Exomine.js to look out for this
+        // Event listener will have an if statement that makes sure that ALL NECESSARY SELECTIONS have been made prior to executing this function - otherwise, it will return an error message.
+    
+    //Function will check to see if an object within colony mineral joins exists that has colony id and mineral Id that matches mineral and colony within transient state
+        // currently transient state does not have functionality to have colonyID and mineralID, only governorID and selectedFacilityMineralId
+
+    // IF object does exist with this mineral Id and colony Id
+        // increase tons in colonyMineralJoin by 1
+        // decrement tons in facilityMineralJoin by 1
+        // reset transient state
+
+    // Else....
+        //need to create a new object!
+            // newObject.colonyID = transientState.selectedColony
+            // newObject.mineralID = transientState.selectedMineral
+            // use colonyMineralJoins.length to grab the last object and find its Id
+            // newObject.tons = 1
+        //
+
+
     // Broadcast custom event to entire documement so that the
     // application can re-render and update state
     document.dispatchEvent(new CustomEvent("stateChanged"))
@@ -200,4 +220,10 @@ export const setGovernor = (governorId) => {
     database.transientState.selectedGovernor = governorId
     document.dispatchEvent(new CustomEvent("stateChanged"))
 }
+
+export const setMineral = (mineralId) => {
+    database.transientState.selectedMineral = mineralId
+    document.dispatchEvent(new CustomEvent("stateChanged"))
+}
+
 


### PR DESCRIPTION
# Description

added setMineral function to database that adds current mineral ID to transient state. this function is invoked whenever someone chooses a mineral at a facility (selectedMineral is set to the corresponding mineralID), deselects a facility (selectedMineral is set back to 0), or deselects a governor (selectedMineral is set back to 0)

Fixes # (41)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. serve in browser
2. pick a governor, facility, and mineral option. Check console to make sure "selectedMineral" was added to transient state.
3. Try going through the process twice, deselecting facility the first time and deselecting governor the second time. "SelectedMineral" should be reset to zero in both cases. 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
